### PR TITLE
Switch to llama.cpp backend

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY requirements.txt .
 RUN apt-get update \
-    && apt-get install -y build-essential \
+    && apt-get install -y build-essential git \
     && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir -r requirements.txt
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,14 +1,12 @@
 from fastapi import FastAPI, Request, Form
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
-from llama_cpp import Llama
-import os
+from agent import ask_llm
 
 app = FastAPI()
 templates = Jinja2Templates(directory="templates")
 
-MODEL_PATH = os.getenv("MODEL_PATH", "./models/google_gemma-3-4b-it-qat-Q4_0.gguf")
-llm = Llama(model_path=MODEL_PATH, n_ctx=2048, n_threads=4)
+
 
 conversation_history = []
 
@@ -25,14 +23,12 @@ async def index(request: Request):
 @app.post("/chat", response_class=HTMLResponse)
 async def chat(request: Request, user_input: str = Form(...)):
     conversation_history.append(f"User: {user_input}")
-    prompt = "\n".join([msg.replace("User:", "User:").replace("Agent:", "Assistant:") for msg in conversation_history])
-    prompt += f"\nUser: {user_input}\nAssistant:"
+    prompt = "\n".join(
+        [msg.replace("User:", "User:").replace("Agent:", "Assistant:") for msg in conversation_history]
+    )
+    prompt += "\nAssistant:"
 
-    try:
-        output = llm(prompt, max_tokens=512, stop=["User:", "Assistant:"], echo=False)
-        agent_reply = output["choices"][0]["text"].strip()
-    except Exception as e:
-        agent_reply = f"[chyba: {e}]"
+    agent_reply = ask_llm(prompt)
 
     conversation_history.append(f"Agent: {agent_reply}")
     return await index(request)


### PR DESCRIPTION
## Summary
- remove Ollama-based helper and replace with llama.cpp
- use the helper in main.py and clean up prompt building
- ensure Dockerfile installs git to build llama-cpp

## Testing
- `python3 -m py_compile app/main.py app/agent.py app/tools/web_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_6842c4dd45e08330ab5266679d287fbf