### PR TITLE
Add LLM microservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # AI Agent Project
 
-This repository provides a small FastAPI server that exposes a chat page backed by a local [llama.cpp](https://github.com/ggerganov/llama.cpp) model. The model is loaded using `llama-cpp-python`.
+This repository provides a small FastAPI chat server backed by a
+local [llama.cpp](https://github.com/ggerganov/llama.cpp) model. The server and
+model can run either together or as two separate containers.
 
 ## Requirements
 
@@ -17,6 +19,8 @@ Place your GGUF model in `app/models` and set the `MODEL_PATH` environment varia
 
 ## Running
 
+### Local run
+
 Start the FastAPI server with uvicorn:
 
 ```bash
@@ -24,4 +28,14 @@ uvicorn main:app --host 0.0.0.0 --port 8000 --app-dir app
 ```
 
 Visit `http://localhost:8000` in your browser to chat with the model.
+
+### Docker Compose
+
+To run the server and the model in separate containers:
+
+```bash
+docker compose up --build
+```
+
+The chat UI will be available on port `8000` and the LLM service on `8001`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,14 @@
+version: '3'
 services:
-  agent:
+  server:
     build: ./app
-    network_mode: "host"
+    ports:
+      - "8000:8000"
+    environment:
+      - LLM_SERVER_URL=http://llm:8001/generate
+  llm:
+    build: ./llm_service
     volumes:
-      - ./app:/app
-    working_dir: /app
-    command: uvicorn main:app --host 0.0.0.0 --port 8000
+      - ./app/models:/app/models
+    ports:
+      - "8001:8001"

--- a/llm_service/Dockerfile
+++ b/llm_service/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN apt-get update \
+    && apt-get install -y build-essential git \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/llm_service/main.py
+++ b/llm_service/main.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from llama_cpp import Llama
+import os
+
+MODEL_PATH = os.getenv("MODEL_PATH", "./models/google_gemma-3-4b-it-qat-Q4_0.gguf")
+
+if not os.path.isfile(MODEL_PATH):
+    raise FileNotFoundError(
+        f"Model file not found: {MODEL_PATH}. Set the MODEL_PATH environment variable"
+    )
+
+llm = Llama(model_path=MODEL_PATH, n_ctx=2048, n_threads=2)
+
+app = FastAPI()
+
+class Prompt(BaseModel):
+    prompt: str
+    max_tokens: int = 512
+
+@app.post("/generate")
+async def generate(p: Prompt):
+    output = llm(p.prompt, max_tokens=p.max_tokens, stop=["User:", "Assistant:"], echo=False)
+    return {"text": output["choices"][0]["text"].strip()}

--- a/llm_service/requirements.txt
+++ b/llm_service/requirements.txt
@@ -1,0 +1,8 @@
+requests
+beautifulsoup4
+fastapi
+uvicorn
+pydantic
+python-multipart
+jinja2
+llama-cpp-python


### PR DESCRIPTION
## Summary
- support running FastAPI chat UI and llama.cpp model in separate containers
- update main server to call the LLM service over HTTP
- document the new Docker Compose workflow

## Testing
- `python -m py_compile app/main.py llm_service/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6843342040d88330bd1e991dabd36fc4